### PR TITLE
don't release build-time stuff to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+docs
+node_modules
+_config.yml
+.editorconfig
+.hound.yml
+.gitignore
+gruntfile.js

--- a/css/.fabric-stats.md
+++ b/css/.fabric-stats.md
@@ -1,6 +1,6 @@
 # [@wealthsimple/fabric]( http://fabric.wealthsimple.com )
 
-**Version:** `3.1.0`
+**Version:** `3.1.2`
 
 > Fabric is the CSS toolkit that powers Wealthsimple's front-end design. It's purposefully limited to common components to provide our developers with the most flexibility. It's built with SCSS and available via Bower, so it's easy to include all or part of it within your own project.
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@wealthsimple/fabric",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "homepage": "http://fabric.wealthsimple.com",
   "author": "Wealthsimple",
-  "scss": "./scss/fabric.scss",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,10 +13,11 @@
     "url": "https://github.com/wealthsimple/fabric/issues"
   },
   "main": "css/fabric.css",
+  "scss": "./scss/fabric.scss",
   "directories": {
     "doc": "docs"
   },
-  "dependencies": {
+  "devDependencies": {
     "autoprefixer-core": "~5.2.1",
     "grunt-jekyll": "^0.4.2",
     "grunt-autoprefixer": "^2.2.0",


### PR DESCRIPTION
One of the benefits of `npm` over `bower` is that we can control what files go in npm's registry independently of what goes into github using an `.npmignore` file.  This PR hooks that up.

I also moved our build time deps out of 'dependencies' and into 'devDependencies'. This follows established conventions. It also stops consuming projects from having retireJS flag stuff that isn't actually shipped in prod.