### PR TITLE
Feature/hide number input arrows

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -22,6 +22,7 @@ Form elements in Fabric currently have no basic layout specified (this is by des
 <form>
   <input type="text" class="form-input-text" placeholder="Name">
   <input type="email" class="form-input-text" placeholder="Email address">
+  <input type="number" class="form-input-text" placeholder="Age">
 
   <p>
     <label>

--- a/scss/_normalize.scss
+++ b/scss/_normalize.scss
@@ -20,6 +20,9 @@ input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+input[type=number] {
+  -moz-appearance: textfield;
+}
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;

--- a/scss/_normalize.scss
+++ b/scss/_normalize.scss
@@ -15,6 +15,11 @@ input[type="search"] {
     -webkit-appearance: none;
     border-radius:3px;
 }
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;


### PR DESCRIPTION
This PR removes the up and down arrows in input fields that are of type number. By doing so, we can stop using `type="text"` for numeric values, and use the more semantic `type="number"` instead.

![screen shot 2017-09-07 at 4 32 41 pm](https://user-images.githubusercontent.com/1329167/30183957-4eeb5374-93ea-11e7-9d72-0d355409cc98.png)
