### PR TITLE
use backslash for all links to prevent github pages redirect to wealthsimple.github.io

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -18,7 +18,7 @@
         </a>
 
         <nav class="masthead-nav">
-          <a {% if page.layout == "page" %}class="active"{% endif %} href="{{ site.baseurl }}/scaffolding">Docs</a>
+          <a {% if page.layout == "page" %}class="active"{% endif %} href="{{ site.baseurl }}/scaffolding/">Docs</a>
           <a href="{{ site.github.repo }}" target="_blank">GitHub</a>
           <a href="{{ site.github.repo }}/blob/master/README.md#install" target="_blank">Install</a>
         </nav>


### PR DESCRIPTION
the Cloudfront fix didn't seem to work, so this is solution #2 